### PR TITLE
Add missing assertion macro parentheses

### DIFF
--- a/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime.h
+++ b/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime.h
@@ -110,7 +110,7 @@ typedef int hipLaunchParm;
 #undef assert
 #define assert(COND)                                                                               \
   {                                                                                                \
-    if (!COND) {                                                                                   \
+    if (!(COND)) {                                                                                 \
       abort_();                                                                                    \
     }                                                                                              \
   }


### PR DESCRIPTION
The `assert` macro in `nvidia_detail` is not properly parenthesized, leading to unexpected behavior.