### PR TITLE
fix typo in hipBatchMemOpParamsTocudaBatchMemOpParams

### DIFF
--- a/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -665,7 +665,7 @@ static inline void hipBatchMemOpParamsTocudaBatchMemOpParams(CUstreamBatchMemOpP
             a[i].writeValue.alias = (CUdeviceptr)(p[i].writeValue.alias);
         }
         else if (p[i].memoryBarrier.operation == hipStreamMemOpBarrier) {
-            a[i].memoryBarrier.operation == CU_STREAM_MEM_OP_BARRIER;
+            a[i].memoryBarrier.operation = CU_STREAM_MEM_OP_BARRIER;
             a[i].memoryBarrier.flags = p[i].memoryBarrier.flags;
         }
         else if (p[i].flushRemoteWrites.operation == hipStreamMemOpFlushRemoteWrites) {


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
Closes #5

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Fixes a typo in hipBatchMemOpParamsTocudaBatchMemOpParams - replaces equality test with assignment.

## Why are these changes needed?

Assignment is expected in equality

## Updated CHANGELOG?

There is no changelog

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
