### PR TITLE
SWDEV-545953 - Add Nvidia mapping for hipStreamGetId

### DIFF
--- a/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -3178,6 +3178,10 @@ inline static hipError_t hipStreamGetFlags(hipStream_t stream, unsigned int *fla
     return hipCUDAErrorTohipError(cudaStreamGetFlags(stream, flags));
 }
 
+inline static hipError_t hipStreamGetId(hipStream_t stream, unsigned long long *streamId) {
+    return hipCUDAErrorTohipError(cudaStreamGetId(stream, streamId));
+}
+
 inline static hipError_t hipStreamGetPriority(hipStream_t stream, int *priority) {
     return hipCUDAErrorTohipError(cudaStreamGetPriority(stream, priority));
 }


### PR DESCRIPTION
 SWDEV-545953

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Added Nvidia mapping for hipStreamGetId API.

## Why are these changes needed?

This API is newly added in hip and hence nvidia mapping should be added for it work on cuda backend.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [x] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
